### PR TITLE
Revert to original behavior

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,13 @@ jobs:
         run: |
           VERSION=`cat semver.txt`
           OUTPUT=./nupkgs
-          echo "version=$VERSION" >> $env:GITGUB_OUTPUT
-          echo "core_package_name=Yextly.DotNetOutdatedTool.Core.$VERSION.nupkg" >> $env:GITGUB_OUTPUT
-          echo "core_symbol_package_name=Yextly.DotNetOutdatedTool.Core.$VERSION.snupkg" >> $env:GITGUB_OUTPUT
-          echo "core_package_filename=$OUTPUT/Yextly.DotNetOutdatedTool.Core.$VERSION.nupkg" >> $env:GITGUB_OUTPUT
-          echo "core_symbol_package_filename=$OUTPUT/Yextly.DotNetOutdatedTool.Core.$VERSION.snupkg" >> $env:GITGUB_OUTPUT
-          echo "tool_package_name=yextly-dotnet-outdated-tool.$VERSION.nupkg" >> $env:GITGUB_OUTPUT
-          echo "tool_package_filename=$OUTPUT/yextly-dotnet-outdated-tool.$VERSION.nupkg" >> $env:GITGUB_OUTPUT
+          echo "##[set-output name=version;]$VERSION"
+          echo "##[set-output name=core_package_name;]Yextly.DotNetOutdatedTool.Core.$VERSION.nupkg"
+          echo "##[set-output name=core_symbol_package_name;]Yextly.DotNetOutdatedTool.Core.$VERSION.snupkg"
+          echo "##[set-output name=core_package_filename;]$OUTPUT/Yextly.DotNetOutdatedTool.Core.$VERSION.nupkg"
+          echo "##[set-output name=core_symbol_package_filename;]$OUTPUT/Yextly.DotNetOutdatedTool.Core.$VERSION.snupkg"
+          echo "##[set-output name=tool_package_name;]yextly-dotnet-outdated-tool.$VERSION.nupkg"
+          echo "##[set-output name=tool_package_filename;]$OUTPUT/yextly-dotnet-outdated-tool.$VERSION.nupkg"
           dotnet build --configuration Release
           dotnet pack --configuration Release /p:Version=$VERSION --output $OUTPUT
 


### PR DESCRIPTION
After trying to fix the pipeline without success, let's revert it back waiting for the documentation to be useful: using the powershell syntax `$env:GITHUB_OUTPUT` does not produce errors, but the variables are empty.